### PR TITLE
Removed CMake hacks for optional dependencies

### DIFF
--- a/Dockerfile-crosseth
+++ b/Dockerfile-crosseth
@@ -85,7 +85,7 @@ ENV CPP_ETHEREUM_BRANCH develop
 # See "Build break - armel - invalid use of incomplete type 'class std::future<void>"
 # https://github.com/doublethinkco/cpp-ethereum-cross/issues/111
 #
-ENV CPP_ETHEREUM_COMMIT edfafc4
+ENV CPP_ETHEREUM_COMMIT e1ba214
 
 # Clone the webthree-umbrella repo into the docker container, including sub-modules
 WORKDIR /home/crosseth

--- a/cross-build/ethereum/cpp-ethereum.sh
+++ b/cross-build/ethereum/cpp-ethereum.sh
@@ -32,31 +32,6 @@ cd_clone ${INITIAL_DIR?}/../.. ${WORK_DIR?}/cpp-ethereum
 export_cross_compiler && sanity_check_cross_compiler
 
 
-# ===========================================================================
-# configuration:
-
-section_configuring cpp-ethereum
-
-# ---------------------------------------------------------------------------
-# hacks
-
-clone ${INITIAL_DIR?}/../../cmake ${WORK_DIR?}/cmake # clones without cd-ing
-generic_hack \
-  ${WORK_DIR?}/cmake/UseEth.cmake \
-  '!/Eth::ethash-cl Cpuid/'
-generic_hack \
-  ${WORK_DIR?}/cmake/UseDev.cmake \
-  '!/Miniupnpc/'
-
-generic_hack \
-  ${WORK_DIR?}/cpp-ethereum/libethcore/CMakeLists.txt \
-  '!/Eth::ethash-cl Cpuid/'
-
-# configuration hack to remove miniupnp (optional and broken at the moment)
-generic_hack \
-  ${WORK_DIR?}/cpp-ethereum/libp2p/CMakeLists.txt \
-  '!/Miniupnpc/'
-
 # ---------------------------------------------------------------------------
 set_cmake_paths "boost:cryptopp:curl:gmp:jsoncpp:leveldb::libjson-rpc-cpp:libmicrohttpd"
 


### PR DESCRIPTION
It looks like all the CMake cleanup in cpp-ethereum has rendered them redundant.